### PR TITLE
Fix reversed value bars in CPU games

### DIFF
--- a/issues/player-bars-reversed.md
+++ b/issues/player-bars-reversed.md
@@ -19,3 +19,6 @@ Relevant code snippets:
 - Bar animation uses `innerBar1` for the first value and `innerBar2` for the second value.
 - `changeAndResetUI` swaps the `compbar1` and `compbar2` classes, potentially causing the bars to appear in the opposite order.
 
+## Status
+Fixed. `changeAndResetUI` now swaps the corresponding `innerbar` elements so player and computer values align with their visual order.
+

--- a/public/compareFuncs.js
+++ b/public/compareFuncs.js
@@ -451,9 +451,11 @@ const startGame = () => {
         setCardPropertyNames();
         clearInterval(dotinterval);
         player1Card.classList.replace('c1', 'c2');
-        player2Card.classList.replace('c2', 'c1'); 
+        player2Card.classList.replace('c2', 'c1');
         compbar1.classList.replace('compbar1', 'compbar2');
         compbar2.classList.replace('compbar2', 'compbar1');
+        compbar1.appendChild(innerBar2);
+        compbar2.appendChild(innerBar1);
         player2Deck.classList.replace('player2Deck', 'player1Deck');
 
         setTimeout (() => {


### PR DESCRIPTION
## Summary
- Swap inner bar elements when changing UI so player value appears on top
- Document resolution for reversed bar issue

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68a6ea3f0bc88320a7e07396890b0ce4