### PR TITLE
Add modern theme toggle

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="modern.css">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
     <script src="https://kit.fontawesome.com/88df1645ec.js" crossorigin="anonymous"></script>
     <title>Welcome to Firebase Hosting</title>
 
@@ -25,8 +27,10 @@
   </head>
   <body>
     <div class="playground">
-      <div class="navbar"> <h1>Super Trumpf!</h1>
+      <div class="navbar">
+          <h1>Super Trumpf!</h1>
           <h2>Spiele das Kult-Game Online!</h2>
+          <button id="style-toggle">Modernes Design</button>
       </div>
       <form action="click" id = "startform" class="startform">
        <input type="button" value="Platzhalter1">
@@ -216,7 +220,13 @@
 </script>
            <script src="decks.js"></script>
            <script src="indexListeners.js"></script>
-     
+           <script>
+             const styleToggleBtn = document.getElementById('style-toggle');
+             styleToggleBtn.addEventListener('click', () => {
+               document.body.classList.toggle('modern');
+               styleToggleBtn.textContent = document.body.classList.contains('modern') ? 'Klassisches Design' : 'Modernes Design';
+             });
+           </script>
 
   </body>
 </html>

--- a/public/modern.css
+++ b/public/modern.css
@@ -1,0 +1,57 @@
+body.modern {
+  font-family: 'Roboto', sans-serif;
+  background: #121212;
+  color: #f0f0f0;
+}
+
+body.modern .playground {
+  background: #111827;
+  min-height: 100vh;
+}
+
+body.modern .navbar {
+  background: #1e1e1e;
+  padding: 1rem;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.5);
+  position: relative;
+}
+
+body.modern .navbar h1 {
+  color: #3b82f6;
+}
+
+body.modern .navbar h2 {
+  color: #9ca3af;
+}
+
+body.modern #style-toggle {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  background: #3b82f6;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+
+body.modern #style-toggle:hover {
+  background: #2563eb;
+}
+
+body.modern .startform input[type="button"],
+body.modern .startform button {
+  background: #3b82f6;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  margin: 0.5rem;
+  font-size: 1rem;
+}
+
+body.modern .startform input[type="button"]:hover,
+body.modern .startform button:hover {
+  background: #2563eb;
+}


### PR DESCRIPTION
## Summary
- add modern.css with updated fonts and colors
- add toggle button in navbar to switch between classic and modern theme
- inline script swaps body class and button label

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a6efee67ec8320a12375155173b24d